### PR TITLE
Add opengraph images for social media

### DIFF
--- a/_posts/2018-06-02-interview-process.md
+++ b/_posts/2018-06-02-interview-process.md
@@ -2,6 +2,7 @@
 layout: post
 title: Why Are Technical Interviews So Hard?
 tags: [Technical, Interviews, Hard]
+image: /assets/img/pexels/whiteboard.jpg
 excerpt_separator: <!--more-->
 ---
 

--- a/_posts/2018-06-10-big-o-doughnuts.md
+++ b/_posts/2018-06-10-big-o-doughnuts.md
@@ -2,6 +2,7 @@
 layout: post
 title: Big O Explained With Doughnuts
 tags: [Big O, Doughnuts]
+image: /assets/img/pexels/doughnut-sprinkle.jpg
 excerpt_separator: <!--more-->
 ---
 

--- a/_posts/2018-06-14-love-yourself-dog.md
+++ b/_posts/2018-06-14-love-yourself-dog.md
@@ -2,6 +2,7 @@
 layout: post
 title: Imagine Yourself as Lovable as Your Dog
 tags: [Imagination, Self, Lovable, Dogs]
+image: /assets/img/pexels/dog-smile.jpg
 excerpt_separator: <!--more-->
 ---
 


### PR DESCRIPTION
The `image` variable in the front-matter gets picked up by the `jekyll-seo` plugin, which generates an opengraph image tag in the page's final HTML source. These opengraph tags get interpreted by sites like Twitter to give posts from your blog a thumbnail image!